### PR TITLE
ルーム削除機能の追加（turbo_method）

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -19,7 +19,9 @@ class RoomsController < ApplicationController
     @room = Room.find(params[:id])
   end
 
-  def edit; end
-
-  def destroy; end
+  def destroy
+    room = Room.find(params[:id])
+    room.destroy
+    redirect_to root_path, status: :see_other, notice: 'ルームを削除しました。'
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Room < ApplicationRecord
-  has_one :map
+  has_one :map, dependent: :destroy
 end

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -21,3 +21,4 @@ table
       td= @room.map.updated_at
 
 = link_to 'マップ編集', edit_room_map_path(@room, @room.map), class: 'btn'
+= link_to 'ルーム削除', @room, data: { turbo_method: :delete, turbo_confirm: 'ルームを削除します。よろしいですか？' }, class: 'btn'


### PR DESCRIPTION
turbo_methodを使って削除ボタンを追加しました。
redirectの際に、status: :seeを追加しないと、リダイレクト先へGETではなくDELETEしてしまうので注意
[Rails 7: link\_to delete not working \(wrong redirect\) · Issue \#44170 · rails/rails](https://github.com/rails/rails/issues/44170)
[status: :see\_other](https://guides.rubyonrails.org/getting_started.html#deleting-an-article)