### PR TITLE
マップのcreateアクションを変更した（has_one関連付の場合、build_associationを使う）

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -6,10 +6,11 @@ class MapsController < ApplicationController
   end
 
   def create
-    @map = Map.new_by(params[:room_id], map_params)
+    @room = Room.find(params[:room_id])
+    @map = @room.build_map(map_params)
 
     if @map.save!
-      redirect_to @map.room, notice: 'マップを登録しました。'
+      redirect_to @room, notice: 'マップを登録しました。'
     else
       render :new
     end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -2,9 +2,4 @@
 
 class Map < ApplicationRecord
   belongs_to :room
-
-  def self.new_by(room_id, map_params)
-    room = Room.find(room_id)
-    room.map = Map.new(map_params)
-  end
 end


### PR DESCRIPTION
> 新しく作成したhas\_one関連付けまたはbelongs\_to関連付けを初期化するには、association\.buildメソッドではなくbuild\_で始まるメソッドを使う必要があります（association\.buildはhas\_many関連付けやhas\_and\_belongs\_to\_many関連付けで使われます）。関連付けを作成する場合も、create\_で始まるメソッドをお使いください。

[LINK](https://railsguides.jp/association_basics.html)

[has\_one関係のあるモデルをbuildするときは注意 \- Qiita](https://qiita.com/tsuchinoko_run/items/c56739c48deb91ac1e3f)
[railsのnewとbuildの違い \- Qiita](https://qiita.com/ryosuke-endo/items/6bae532b4f678fdcf87d)