### PR TITLE
ルームコントローラーからnewを外す

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
 class RoomsController < ApplicationController
-  def new
-    create
-  end
-
   def create
     @room = Room.new
 
     if @room.save
       redirect_to new_room_map_path(@room)
     else
-      redirect_to new_room_path
+      redirect_to root_path
     end
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,7 +2,7 @@
 
 class Room < ApplicationRecord
   has_one :map, dependent: :destroy
-  before_create :set_id
+  before_save :set_id
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'marks/new'
-  get 'marks/create'
-  get 'marks/edit'
-  get 'marks/update'
-  get 'marks/destroy'
   # あとでやる：ルートをランダムURLにする方法
-  root to: 'rooms#new'
+  root to: 'rooms#create'
   resources :rooms, except: %i[index edit create] do
     resources :maps, except: %i[index show destroy]
     resources :marks, except: :index

--- a/spec/system/maps_spec.rb
+++ b/spec/system/maps_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'マップ管理機能', type: :system do
   describe '新規作成機能' do
     before do
-      visit new_room_path
+      visit root_path
       fill_in 'Trimming', with: '10, 20'
       fill_in 'Expansion', with: '30'
       fill_in 'Rotation', with: '40'


### PR DESCRIPTION
本番でルームのbefore_createがRoom.new.saveでコールバックしなかったので、before_saveにしたところコールバックした。
開発ではどちらでも動いたので謎。