### PR TITLE
初登録時にtrimmingにnullが入ってしまい、エラーになっていたので、nullの場合は初期値を与えるようにした #17

### DIFF
--- a/app/javascript/components/image_show.vue
+++ b/app/javascript/components/image_show.vue
@@ -47,8 +47,8 @@ export default {
 
     try {
       this.trimming = JSON.parse(response.trimming)
-    } catch {
-      this.trimming = {x: 0, y: 0}
+    } finally {
+      this.trimming ||= {x: 0, y: 0}
     }
   },
   updated() {


### PR DESCRIPTION
本番で異常を確認したので再度同ブランチからPR